### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      
+      - name: Setup environment
+        run: cp .env.example .env.production
+      
+      - name: Install dependencies
+        run: bun install
+      
+      - name: Build
+        run: bun run build
+        env:
+          NEXT_PUBLIC_BASE_PATH: /etherguild
+      
+      - name: Export static site
+        run: bun run next export
+      
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: out
+          branch: gh-pages


### PR DESCRIPTION
Set up automated deployment to GitHub Pages using GitHub Actions. This workflow will build the Next.js app with Bun and deploy it to gh-pages branch whenever changes are pushed to main.

Testing deployment on my fork to share progress with the Discord group.